### PR TITLE
[add]カメラの角度をジャイロセンサーで動かせるようにした

### DIFF
--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -240,7 +240,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1309685b345aed1488820d5b623307a6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  cube: {fileID: 188317383394879714, guid: 5342cc583676bad418318de629e9768d, type: 3}
 --- !u!4 &784364639
 Transform:
   m_ObjectHideFlags: 0
@@ -266,6 +265,7 @@ GameObject:
   - component: {fileID: 963194228}
   - component: {fileID: 963194227}
   - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -338,6 +338,18 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12c6c21f44777ce4584bd4e6d6378f09, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1353756420
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/gryo.cs
+++ b/Assets/Scripts/gryo.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class gryo : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        Input.gyro.enabled = true;
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        transform.rotation = Quaternion.AngleAxis(90.0f, Vector3.right) * Input.gyro.attitude * Quaternion.AngleAxis(180.0f, Vector3.forward);
+    }
+}

--- a/Assets/Scripts/gryo.cs.meta
+++ b/Assets/Scripts/gryo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12c6c21f44777ce4584bd4e6d6378f09
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Gameシーンを加速度センサーでぐるぐるできるように[4](https://trello.com/c/Xv8AKlSj/4-game%E3%82%B7%E3%83%BC%E3%83%B3%E3%82%92%E5%8A%A0%E9%80%9F%E5%BA%A6%E3%82%BB%E3%83%B3%E3%82%B5%E3%83%BC%E3%81%A7%E3%81%90%E3%82%8B%E3%81%90%E3%82%8B%E3%81%A7%E3%81%8D%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB)に対するPRです。


# 主な変更、追加箇所  
- main cameraにgryoという角度をジャイロセンサーで変えられるスクリプトを追加した。
-
-

# 詳細
特記事項あれば

