### PR TITLE
[add]新しいadd除外ファイル, Playerに当たり判定

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Thumbs.db
 
 #log files, for some plugins
 *.log
+UpgradeLog*.htm
 
 #python bytecode cache, for some plugins.
 *.pyc

--- a/Assets/VrScenes/Vr.unity
+++ b/Assets/VrScenes/Vr.unity
@@ -433,8 +433,9 @@ GameObject:
   - component: {fileID: 963194229}
   - component: {fileID: 963194230}
   - component: {fileID: 963194231}
+  - component: {fileID: 963194232}
   m_Layer: 0
-  m_Name: Main Camera
+  m_Name: Player
   m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -499,7 +500,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -528,7 +529,7 @@ Rigidbody:
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
-  m_UseGravity: 0
+  m_UseGravity: 1
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0
@@ -547,6 +548,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moving_speed: 1
   rigitbody: {fileID: 0}
+--- !u!136 &963194232
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  m_Radius: 0.5
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &1074639347
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
タスク[31](https://trello.com/c/oAeVX16q/45-%E3%83%97%E3%83%AC%E3%82%A4%E3%83%A4%E3%83%BC%E3%81%AB%E5%BD%93%E3%81%9F%E3%82%8A%E5%88%A4%E5%AE%9A%E3%82%92%E3%81%A4%E3%81%91%E3%82%8B-31)に対するPRです。


# 主な変更、追加箇所  
- VrScenesのMainCameraの名前をPlayerに変更
- PlayerにCapsule Colliderを追加
- PlayerのRigidBobyのUseGravityをONにした
- Playerの元の初期位置だと重力で奈落に落下してしまうため，初期位置をx:0, y:1, z:0にした

# 詳細


