### PR TITLE
59[add]Androidの戻るボタンでTitle Sceneに戻るようにした

### DIFF
--- a/Assets/TitleScenes/Scripts/BugsnagInit.cs.meta
+++ b/Assets/TitleScenes/Scripts/BugsnagInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ba49d0775a0a5e41876d1448a58fb8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/VrScenes/Scripts/GameManager.cs
+++ b/Assets/VrScenes/Scripts/GameManager.cs
@@ -5,14 +5,11 @@ using UnityEngine.SceneManagement;
 
 public class GameManager : MonoBehaviour
 {
-   public void Back_To_Title_If_Needed()
+   public void Back_To_Title_If_Android()
     {
         if (Application.platform == RuntimePlatform.Android)
         {
-            if (Input.GetKeyDown(KeyCode.Escape))
-            {
                 SceneManager.LoadScene("Title");
-            }
         }
     }
 }

--- a/Assets/VrScenes/Scripts/GameManager.cs
+++ b/Assets/VrScenes/Scripts/GameManager.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class GameManager : MonoBehaviour
+{
+   public void Back_To_Title_If_Needed()
+    {
+        if (Application.platform == RuntimePlatform.Android)
+        {
+            if (Input.GetKeyDown(KeyCode.Escape))
+            {
+                SceneManager.LoadScene("Title");
+            }
+        }
+    }
+}

--- a/Assets/VrScenes/Scripts/GameManager.cs.meta
+++ b/Assets/VrScenes/Scripts/GameManager.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8e5ef73522d5d8d489d4610745d66a16
+guid: 999a763357c17ed4e83122bf797d7598
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -35,7 +35,7 @@ public class InputManager : MonoBehaviour
         else if (Input.GetKey("s")) playermanager.Move_Back();
         else if (Input.GetKeyUp("s")) playermanager.StopMove();
 
-        gamemanager.Back_To_Title_If_Needed();
+        if (Input.GetKeyDown(KeyCode.Escape)) gamemanager.Back_To_Title_If_Android();
     }
 
     public void Player_Forward()

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -7,10 +7,18 @@ public class InputManager : MonoBehaviour
     PlayerManager playermanager;
     GameObject player;
 
+
+    GameManager gamemanager;
+    GameObject gamesystem;
+
+
     void Start()
     {
         player = GameObject.FindGameObjectWithTag("Player");
         playermanager = player.GetComponent<PlayerManager>();
+
+        gamesystem = GameObject.Find("GameSystem");
+        gamemanager = gamesystem.GetComponent<GameManager>();
     }
 
     private void Update()
@@ -26,6 +34,8 @@ public class InputManager : MonoBehaviour
 
         else if (Input.GetKey("s")) playermanager.Move_Back();
         else if (Input.GetKeyUp("s")) playermanager.StopMove();
+
+        gamemanager.Back_To_Title_If_Needed();
     }
 
     public void Player_Forward()

--- a/Assets/VrScenes/Vr.unity
+++ b/Assets/VrScenes/Vr.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 705507994}
-  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1} 
+  m_IndirectSpecularColor: {r: 0.4465782, g: 0.49641252, b: 0.5748167, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -548,6 +548,7 @@ GameObject:
   - component: {fileID: 784364639}
   - component: {fileID: 784364640}
   - component: {fileID: 784364638}
+  - component: {fileID: 784364641}
   m_Layer: 0
   m_Name: GameSystem
   m_TagString: Untagged
@@ -591,6 +592,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1309685b345aed1488820d5b623307a6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &784364641
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784364637}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 999a763357c17ed4e83122bf797d7598, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &963194225


### PR DESCRIPTION
タスク[59](https://trello.com/c/HmRJUw9w/59-vr%E3%82%B7%E3%83%BC%E3%83%B3%E3%81%8B%E3%82%89title%E3%82%B7%E3%83%BC%E3%83%B3%E3%81%ABandroid%E3%81%AE%E6%88%BB%E3%82%8B%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%A7%E6%88%BB%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB)に対するPRです。  


# 主な変更、追加箇所  
- VR SceneでAndroidの戻るボタンが押されるとTitle Sceneに戻るようにした  
  - GameSystemオブジェクトにGameManager.csをコンポーネントとして追加  
  - GameManager.cs内の関数をInputManager.csから呼び出すようにした

