### PR TITLE
96[update](51)移動方向の実装方法を変更する

### DIFF
--- a/Assets/TitleScenes/Scripts/BugsnagInit.cs.meta
+++ b/Assets/TitleScenes/Scripts/BugsnagInit.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ba49d0775a0a5e41876d1448a58fb8c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TouchScript/Editor/EditorResources/Icons.meta
+++ b/Assets/TouchScript/Editor/EditorResources/Icons.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 375fcf571e23249898d00c0d11ffbf93
-folderAsset: yes
-timeCreated: 1500984768
-licenseType: Store
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/TouchScript/Examples/_misc/Textures/Icons.meta
+++ b/Assets/TouchScript/Examples/_misc/Textures/Icons.meta
@@ -1,5 +1,0 @@
-fileFormatVersion: 2
-guid: 1ee4a15bf807b4f74821f1869ed9c9c4
-folderAsset: yes
-DefaultImporter:
-  userData: 

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -8,12 +8,13 @@ public class InputManager : MonoBehaviour
     PlayerManager playermanager;
     GameObject player;
 
-
     GameManager gamemanager;
     GameObject gamesystem;
 
     public Toggle toggle;
     public GameObject FlyingButtons;
+
+    bool forward, back, right, left, up, down;
 
 
     void Start()
@@ -33,59 +34,101 @@ public class InputManager : MonoBehaviour
 
     private void Update()
     {
-        if (Input.GetKey("w")) playermanager.Move_Forward();
-        else if (Input.GetKeyUp("w")) playermanager.StopMove();
+        if (Input.GetKey("w")) Player_Forward();
+        else if (Input.GetKeyUp("w")) Player_StopForward();
 
-        else if (Input.GetKey("d")) playermanager.Move_Right();
-        else if (Input.GetKeyUp("d")) playermanager.StopMove();
+        else if (Input.GetKey("d")) Player_Right();
+        else if (Input.GetKeyUp("d")) Player_StopRight();
 
-        else if (Input.GetKey("a")) playermanager.Move_Left();
-        else if (Input.GetKeyUp("a")) playermanager.StopMove();
+        else if (Input.GetKey("a")) Player_Left();
+        else if (Input.GetKeyUp("a")) Player_StopLeft();
 
-        else if (Input.GetKey("s")) playermanager.Move_Back();
-        else if (Input.GetKeyUp("s")) playermanager.StopMove();
+        else if (Input.GetKey("s")) Player_Back();
+        else if (Input.GetKeyUp("s")) Player_StopBack();
 
         if (Input.GetKeyDown(KeyCode.Escape)) gamemanager.Back_To_Title_If_Android();
 
+        Player_MoveDirectionCheck();
+
     }
 
-   public void FlyingModeCheck(bool isActive)
+    public void FlyingModeCheck(bool isActive)
     {
         playermanager.Flying(isActive);
         FlyingButtons.SetActive(isActive);
     }
+
+    void Player_MoveDirectionCheck()
+    {
+        Vector3 moveDirection = Vector3.zero;
+        if (forward) moveDirection.z += 1;
+        if (back) moveDirection.z += -1;
+        if (right) moveDirection.x += 1;
+        if (left) moveDirection.x += -1;
+        if (up) moveDirection.y += 1;
+        if (down) moveDirection.y += -1;
+
+        Debug.Log(moveDirection);
+
+        playermanager.Add_Velocity(moveDirection);
+    }
     public void Player_Forward()
     {
-        playermanager.Move_Forward();
+        forward = true;
     }
 
     public void Player_Right()
     {
-        playermanager.Move_Right();
+        right = true;
     }
 
     public void Player_Left()
     {
-        playermanager.Move_Left();
+        left = true;
     }
 
     public void Player_Back()
     {
-        playermanager.Move_Back();
-    }
-
-    public void Player_Stop()
-    {
-        playermanager.StopMove();
+        back = true;
     }
     public void Player_Up()
     {
-        playermanager.Move_Up();
+        up = true;
     }
 
     public void Player_Down()
     {
-        playermanager.Move_Down();
+        down = true;
+    }
+
+    public void Player_StopForward()
+    {
+        forward = false;
+    }
+
+    public void Player_StopBack()
+    {
+        back = false;
+    }
+
+    public void Player_StopRight()
+    {
+        right = false;
+    }
+
+    public void Player_StopLeft()
+    {
+        left = false;
+    }
+
+    public void Player_StopUp()
+    {
+        up = false;
+    }
+
+    public void Player_StopDown()
+    {
+        down = false;
     }
 
 }

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -75,60 +75,72 @@ public class InputManager : MonoBehaviour
     public void Player_Forward()
     {
         forward = true;
+        playermanager.MoveZ = true;
     }
 
     public void Player_Right()
     {
         right = true;
+        playermanager.MoveX = true;
     }
 
     public void Player_Left()
     {
         left = true;
+        playermanager.MoveX = true;
     }
 
     public void Player_Back()
     {
         back = true;
+        playermanager.MoveZ = true;
     }
     public void Player_Up()
     {
         up = true;
+        playermanager.MoveY = true;
     }
 
     public void Player_Down()
     {
         down = true;
+        playermanager.MoveY = true;
     }
 
     public void Player_StopForward()
     {
         forward = false;
+        playermanager.MoveZ = false;
     }
 
     public void Player_StopBack()
     {
         back = false;
+        playermanager.MoveZ = false;
     }
 
     public void Player_StopRight()
     {
         right = false;
+        playermanager.MoveX = false;
     }
 
     public void Player_StopLeft()
     {
         left = false;
+        playermanager.MoveX = false;
     }
 
     public void Player_StopUp()
     {
         up = false;
+        playermanager.MoveY = false;
     }
 
     public void Player_StopDown()
     {
         down = false;
+        playermanager.MoveY = false;
     }
 
 }

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -61,12 +61,12 @@ public class InputManager : MonoBehaviour
     void Player_MoveDirectionCheck()
     {
         Vector3 moveDirection = Vector3.zero;
-        if (forward) moveDirection.z = 1;
-        if (back) moveDirection.z = -1;
-        if (right) moveDirection.x = 1;
-        if (left) moveDirection.x = -1;
-        if (up) moveDirection.y = 1;
-        if (down) moveDirection.y = -1;
+        if (forward) moveDirection.z += 1;
+        if (back) moveDirection.z += -1;
+        if (right) moveDirection.x += 1;
+        if (left) moveDirection.x += -1;
+        if (up) moveDirection.y += 1;
+        if (down) moveDirection.y += -1;
 
         playermanager.Add_Velocity(moveDirection);
     }
@@ -86,12 +86,14 @@ public class InputManager : MonoBehaviour
     {
         left = true;
         playermanager.MoveX = true;
+        playermanager.MoveLeft = true;
     }
 
     public void Player_Back()
     {
         back = true;
         playermanager.MoveZ = true;
+        playermanager.MoveBack = true;
     }
     public void Player_Up()
     {
@@ -115,6 +117,7 @@ public class InputManager : MonoBehaviour
     {
         back = false;
         playermanager.MoveZ = false;
+        playermanager.MoveBack = false;
     }
 
     public void Player_StopRight()
@@ -127,6 +130,7 @@ public class InputManager : MonoBehaviour
     {
         left = false;
         playermanager.MoveX = false;
+        playermanager.MoveLeft = false;
     }
 
     public void Player_StopUp()

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -69,80 +69,74 @@ public class InputManager : MonoBehaviour
         if (down) moveDirection.y += -1;
 
         playermanager.Add_Velocity(moveDirection);
+
+        Debug.Log("forward = " + forward + ":back = " + back + ":right = " + right + ":left = " + left + ":up = " + up + ":down = " + down);
     }
     public void Player_Forward()
     {
         forward = true;
-        playermanager.MoveZ = true;
+        playermanager.MoveForward = true;
     }
 
     public void Player_Right()
     {
         right = true;
-        playermanager.MoveX = true;
+        playermanager.MoveRight = true;
     }
 
     public void Player_Left()
     {
         left = true;
-        playermanager.MoveX = true;
         playermanager.MoveLeft = true;
     }
 
     public void Player_Back()
     {
         back = true;
-        playermanager.MoveZ = true;
         playermanager.MoveBack = true;
     }
     public void Player_Up()
     {
         up = true;
-        playermanager.MoveY = true;
     }
 
     public void Player_Down()
     {
         down = true;
-        playermanager.MoveY = true;
     }
 
     public void Player_StopForward()
     {
         forward = false;
-        playermanager.MoveZ = false;
+        playermanager.MoveForward = false;
     }
 
     public void Player_StopBack()
     {
         back = false;
-        playermanager.MoveZ = false;
         playermanager.MoveBack = false;
     }
 
     public void Player_StopRight()
     {
         right = false;
-        playermanager.MoveX = false;
+        playermanager.MoveRight = false;
     }
 
     public void Player_StopLeft()
     {
         left = false;
-        playermanager.MoveX = false;
         playermanager.MoveLeft = false;
     }
 
     public void Player_StopUp()
     {
         up = false;
-        playermanager.MoveY = false;
     }
 
     public void Player_StopDown()
     {
         down = false;
-        playermanager.MoveY = false;
     }
 
 }

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -14,9 +14,6 @@ public class InputManager : MonoBehaviour
     public Toggle toggle;
     public GameObject FlyingButtons;
 
-    bool forward, back, right, left, up, down;
-
-
     void Start()
     {
         player = GameObject.FindGameObjectWithTag("Player");
@@ -47,9 +44,6 @@ public class InputManager : MonoBehaviour
         else if (Input.GetKeyUp("s")) Player_StopBack();
 
         if (Input.GetKeyDown(KeyCode.Escape)) gamemanager.Back_To_Title_If_Android();
-
-        Player_MoveDirectionCheck();
-
     }
 
     public void FlyingModeCheck(bool isActive)
@@ -58,83 +52,64 @@ public class InputManager : MonoBehaviour
         FlyingButtons.SetActive(isActive);
     }
 
-    void Player_MoveDirectionCheck()
-    {
-        Vector3 moveDirection = Vector3.zero;
-        if (forward) moveDirection.z += 1;
-        if (back) moveDirection.z += -1;
-        if (right) moveDirection.x += 1;
-        if (left) moveDirection.x += -1;
-        if (up) moveDirection.y += 1;
-        if (down) moveDirection.y += -1;
 
-        playermanager.Add_Velocity(moveDirection);
-    }
     public void Player_Forward()
     {
-        forward = true;
         playermanager.MoveForward = true;
     }
 
     public void Player_Right()
     {
-        right = true;
         playermanager.MoveRight = true;
     }
 
     public void Player_Left()
     {
-        left = true;
         playermanager.MoveLeft = true;
     }
 
     public void Player_Back()
     {
-        back = true;
         playermanager.MoveBack = true;
     }
     public void Player_Up()
     {
-        up = true;
+        playermanager.MoveUp = true;
     }
 
     public void Player_Down()
     {
-        down = true;
+        playermanager.MoveDown = true;
     }
 
     public void Player_StopForward()
     {
-        forward = false;
         playermanager.MoveForward = false;
     }
 
     public void Player_StopBack()
     {
-        back = false;
         playermanager.MoveBack = false;
     }
 
     public void Player_StopRight()
     {
-        right = false;
         playermanager.MoveRight = false;
     }
 
     public void Player_StopLeft()
     {
-        left = false;
         playermanager.MoveLeft = false;
     }
 
     public void Player_StopUp()
     {
-        up = false;
+        playermanager.MoveUp = false;
     }
 
     public void Player_StopDown()
     {
-        down = false;
+        playermanager.MoveDown = false;
     }
 
 }

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -69,8 +69,6 @@ public class InputManager : MonoBehaviour
         if (down) moveDirection.y += -1;
 
         playermanager.Add_Velocity(moveDirection);
-
-        Debug.Log("forward = " + forward + ":back = " + back + ":right = " + right + ":left = " + left + ":up = " + up + ":down = " + down);
     }
     public void Player_Forward()
     {

--- a/Assets/VrScenes/Scripts/InputManager.cs
+++ b/Assets/VrScenes/Scripts/InputManager.cs
@@ -61,14 +61,12 @@ public class InputManager : MonoBehaviour
     void Player_MoveDirectionCheck()
     {
         Vector3 moveDirection = Vector3.zero;
-        if (forward) moveDirection.z += 1;
-        if (back) moveDirection.z += -1;
-        if (right) moveDirection.x += 1;
-        if (left) moveDirection.x += -1;
-        if (up) moveDirection.y += 1;
-        if (down) moveDirection.y += -1;
-
-        Debug.Log(moveDirection);
+        if (forward) moveDirection.z = 1;
+        if (back) moveDirection.z = -1;
+        if (right) moveDirection.x = 1;
+        if (left) moveDirection.x = -1;
+        if (up) moveDirection.y = 1;
+        if (down) moveDirection.y = -1;
 
         playermanager.Add_Velocity(moveDirection);
     }

--- a/Assets/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/VrScenes/Scripts/PlayerManager.cs
@@ -14,7 +14,7 @@ public class PlayerManager : MonoBehaviour
     const string Up = "Up";
     const string Down = "Down";
 
-    public bool MoveRight, MoveLeft, MoveForward, MoveBack;
+    public bool MoveRight, MoveLeft, MoveForward, MoveBack, MoveUp, MoveDown;
 
     private void Awake()
     {
@@ -28,6 +28,20 @@ public class PlayerManager : MonoBehaviour
     void Update ()
     {
         Rotate();
+        Move();
+    }
+
+    void Move()
+    {
+        Vector3 Direction = Vector3.zero;
+        if (MoveForward) Direction.z += 1;
+        if (MoveBack) Direction.z += -1;
+        if (MoveRight) Direction.x += 1;
+        if (MoveLeft) Direction.x += -1;
+        if (MoveUp) Direction.y += 1;
+        if (MoveDown) Direction.y += -1;
+
+        Add_Velocity(Direction);
     }
     public void Add_Velocity(Vector3 moveDirection)
     {

--- a/Assets/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/VrScenes/Scripts/PlayerManager.cs
@@ -34,23 +34,19 @@ public class PlayerManager : MonoBehaviour
     {
         if (MoveX == true)
         {
-            //if (MoveY == false) move_direction.y = 0;
-            //if (MoveZ == false) move_direction.z = 0;
             move_direction.x *= player_rigidbody.transform.right.x;
+            move_direction.z = player_rigidbody.transform.right.z;
         }
 
         if (MoveY == true)
         {
-            //if (MoveX == false) move_direction.x = 0;
-            //if (MoveZ == false) move_direction.z = 0;
             move_direction.y *= player_rigidbody.transform.up.y;
         }
 
         if (MoveZ == true)
         {
-            //if (MoveX == false) move_direction.x = 0;
-            //if (MoveY == false) move_direction.y = 0;
             move_direction.z *= player_rigidbody.transform.forward.z;
+            move_direction.x = player_rigidbody.transform.forward.x;
         }
 
         move_direction.Normalize();

--- a/Assets/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/VrScenes/Scripts/PlayerManager.cs
@@ -14,7 +14,7 @@ public class PlayerManager : MonoBehaviour
     const string Up = "Up";
     const string Down = "Down";
 
-    public bool MoveX, MoveY, MoveZ;
+    public bool MoveX, MoveY, MoveZ, MoveLeft, MoveBack;
 
     private void Awake()
     {
@@ -30,31 +30,49 @@ public class PlayerManager : MonoBehaviour
     {
         Rotate();
     }
-    public void Add_Velocity(Vector3 move_direction)
+    public void Add_Velocity(Vector3 moveDirection)
     {
+
         if (MoveX == true)
         {
-            move_direction.x *= player_rigidbody.transform.right.x;
-            move_direction.z = player_rigidbody.transform.right.z;
+            moveDirection.x *= player_rigidbody.transform.right.x;
+
+                switch (MoveLeft)
+                {
+                    case true:
+                        moveDirection.z += player_rigidbody.transform.right.z * -1;
+                        break;
+
+                    case false:
+                        moveDirection.z += player_rigidbody.transform.right.z;
+                        break;
+                }
         }
 
         if (MoveY == true)
         {
-            move_direction.y *= player_rigidbody.transform.up.y;
+            moveDirection.y *= player_rigidbody.transform.up.y;
         }
 
         if (MoveZ == true)
         {
-            move_direction.z *= player_rigidbody.transform.forward.z;
-            move_direction.x = player_rigidbody.transform.forward.x;
+            moveDirection.z *= player_rigidbody.transform.forward.z;
+
+                switch (MoveBack)
+                {
+                    case true:
+                        moveDirection.x += player_rigidbody.transform.forward.x * -1;
+                        break;
+                    case false:
+                        moveDirection.x += player_rigidbody.transform.forward.x;
+                        break;
+                }
         }
 
-        move_direction.Normalize();
+        moveDirection.Normalize();
 
-        Debug.Log(move_direction);
-
-        if(isDefault_speed) player_rigidbody.velocity = default_move_speed * move_direction;
-        else player_rigidbody.velocity = run_move_speed * move_direction;
+        if(isDefault_speed) player_rigidbody.velocity = default_move_speed * moveDirection;
+        else player_rigidbody.velocity = run_move_speed * moveDirection;
     }
 
     public void Rotate()

--- a/Assets/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/VrScenes/Scripts/PlayerManager.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
-using UnityEngine.UI;
+﻿using UnityEngine;
 
 public class PlayerManager : MonoBehaviour
 {
@@ -16,7 +13,6 @@ public class PlayerManager : MonoBehaviour
     const string Back = "Back";
     const string Up = "Up";
     const string Down = "Down";
-    private string Move_State = Stop;
 
     private void Awake()
     {
@@ -30,97 +26,18 @@ public class PlayerManager : MonoBehaviour
     void Update ()
     {
         Rotate();
-        Move();
     }
-
-    public void Move()
-    {
-        switch (Move_State) {
-            case Stop:
-                Add_Velocity(Vector3.zero);
-                break;
-
-            case Forward:
-                Add_Velocity(gameObject.transform.forward);
-                break;
-            
-            case Right:
-                Add_Velocity(gameObject.transform.right);
-                break;
-            
-            case Left:
-                Add_Velocity(gameObject.transform.right * -1);
-                break;
-
-            case Back:
-                Add_Velocity(gameObject.transform.forward * -1);
-                break;
-
-            case Up:
-                Add_Velocity(gameObject.transform.up);
-                break;
-
-            case Down:
-                Add_Velocity(gameObject.transform.up * -1);
-                break;
-
-        }
-    }
-
-    public void Move_Forward()
-    {
-        Move_State = Forward;
-    }
-
-    public void Move_Right()
-    {
-        Move_State = Right;
-    }
-
-    public void Move_Left()
-    {
-        Move_State = Left;
-    }
-
-    public void Move_Back()
-    {
-        Move_State = Back;
-    }
-
-    public void StopMove()
-    {
-        Move_State = Stop;
-    }
-
-    public void Move_Up()
-    {
-        Move_State = Up;
-    }
-
-    public void Move_Down()
-    {
-        Move_State = Down;
-    }
-
     public void Add_Velocity(Vector3 move_direction)
     {
-        switch (Move_State) {
-            case Up:
-                move_direction.x = 0;
-                move_direction.y = 1;
-                move_direction.z = 0;
-                break;
-            case Down:
-                move_direction.x = 0;
-                move_direction.y = -1;
-                move_direction.z = 0;
-                break;
+        //その方向に移動するときのみ追加するように。
+        move_direction += player_rigidbody.transform.right;
+        move_direction += player_rigidbody.transform.up;
+        move_direction += player_rigidbody.transform.forward;
 
-            default:
-        move_direction.y = 0;
-        move_direction = move_direction.normalized;
-                break;
-    }
+        move_direction.Normalize();
+
+        Debug.Log(move_direction);
+
         if(isDefault_speed) player_rigidbody.velocity = default_move_speed * move_direction;
         else player_rigidbody.velocity = run_move_speed * move_direction;
     }

--- a/Assets/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/VrScenes/Scripts/PlayerManager.cs
@@ -14,6 +14,8 @@ public class PlayerManager : MonoBehaviour
     const string Up = "Up";
     const string Down = "Down";
 
+    public bool MoveX, MoveY, MoveZ;
+
     private void Awake()
     {
         player_rigidbody = GetComponent<Rigidbody>();
@@ -21,6 +23,7 @@ public class PlayerManager : MonoBehaviour
     void Start()
     {
         Input.gyro.enabled = true;
+        MoveX = MoveY = MoveZ = false;
     }
 
     void Update ()
@@ -29,10 +32,26 @@ public class PlayerManager : MonoBehaviour
     }
     public void Add_Velocity(Vector3 move_direction)
     {
-        //その方向に移動するときのみ追加するように。
-        move_direction += player_rigidbody.transform.right;
-        move_direction += player_rigidbody.transform.up;
-        move_direction += player_rigidbody.transform.forward;
+        if (MoveX == true)
+        {
+            //if (MoveY == false) move_direction.y = 0;
+            //if (MoveZ == false) move_direction.z = 0;
+            move_direction.x *= player_rigidbody.transform.right.x;
+        }
+
+        if (MoveY == true)
+        {
+            //if (MoveX == false) move_direction.x = 0;
+            //if (MoveZ == false) move_direction.z = 0;
+            move_direction.y *= player_rigidbody.transform.up.y;
+        }
+
+        if (MoveZ == true)
+        {
+            //if (MoveX == false) move_direction.x = 0;
+            //if (MoveY == false) move_direction.y = 0;
+            move_direction.z *= player_rigidbody.transform.forward.z;
+        }
 
         move_direction.Normalize();
 

--- a/Assets/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/VrScenes/Scripts/PlayerManager.cs
@@ -14,7 +14,7 @@ public class PlayerManager : MonoBehaviour
     const string Up = "Up";
     const string Down = "Down";
 
-    public bool MoveX, MoveY, MoveZ, MoveLeft, MoveBack;
+    public bool MoveRight, MoveLeft, MoveForward, MoveBack;
 
     private void Awake()
     {
@@ -23,7 +23,6 @@ public class PlayerManager : MonoBehaviour
     void Start()
     {
         Input.gyro.enabled = true;
-        MoveX = MoveY = MoveZ = false;
     }
 
     void Update ()
@@ -32,42 +31,14 @@ public class PlayerManager : MonoBehaviour
     }
     public void Add_Velocity(Vector3 moveDirection)
     {
+        moveDirection.x *= player_rigidbody.transform.right.x;
+        moveDirection.y *= player_rigidbody.transform.up.y;
+        moveDirection.z *= player_rigidbody.transform.forward.z;
 
-        if (MoveX == true)
-        {
-            moveDirection.x *= player_rigidbody.transform.right.x;
-
-                switch (MoveLeft)
-                {
-                    case true:
-                        moveDirection.z += player_rigidbody.transform.right.z * -1;
-                        break;
-
-                    case false:
-                        moveDirection.z += player_rigidbody.transform.right.z;
-                        break;
-                }
-        }
-
-        if (MoveY == true)
-        {
-            moveDirection.y *= player_rigidbody.transform.up.y;
-        }
-
-        if (MoveZ == true)
-        {
-            moveDirection.z *= player_rigidbody.transform.forward.z;
-
-                switch (MoveBack)
-                {
-                    case true:
-                        moveDirection.x += player_rigidbody.transform.forward.x * -1;
-                        break;
-                    case false:
-                        moveDirection.x += player_rigidbody.transform.forward.x;
-                        break;
-                }
-        }
+        if (MoveRight) moveDirection.z += player_rigidbody.transform.right.z;
+        if (MoveLeft) moveDirection.z += player_rigidbody.transform.right.z * -1;
+        if (MoveForward) moveDirection.x += player_rigidbody.transform.forward.x;
+        if (MoveBack) moveDirection.x += player_rigidbody.transform.forward.x * -1;
 
         moveDirection.Normalize();
 

--- a/Assets/VrScenes/Vr.unity
+++ b/Assets/VrScenes/Vr.unity
@@ -1251,7 +1251,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 784364638}
-          m_MethodName: Player_Stop
+          m_MethodName: Player_StopDown
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3148,7 +3148,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 784364638}
-          m_MethodName: Player_Stop
+          m_MethodName: Player_StopUp
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3317,7 +3317,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 784364638}
-          m_MethodName: Player_Stop
+          m_MethodName: Player_StopRight
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -3929,7 +3929,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 784364638}
-          m_MethodName: Player_Stop
+          m_MethodName: Player_StopBack
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4173,7 +4173,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 784364638}
-          m_MethodName: Player_Stop
+          m_MethodName: Player_StopLeft
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}
@@ -4424,7 +4424,7 @@ MonoBehaviour:
       m_PersistentCalls:
         m_Calls:
         - m_Target: {fileID: 784364638}
-          m_MethodName: Player_Stop
+          m_MethodName: Player_StopForward
           m_Mode: 1
           m_Arguments:
             m_ObjectArgument: {fileID: 0}

--- a/Assets/VrScenes/Vr.unity
+++ b/Assets/VrScenes/Vr.unity
@@ -2166,6 +2166,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   default_move_speed: 1
   run_move_speed: 2
+  MoveX: 0
+  MoveY: 0
+  MoveZ: 0
+  MoveLeft: 0
+  MoveBack: 0
 --- !u!54 &963194230
 Rigidbody:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
タスク[96](https://trello.com/c/cd4y2KZa/96-51%E7%A7%BB%E5%8B%95%E6%96%B9%E5%90%91%E3%81%AE%E5%AE%9F%E8%A3%85%E6%96%B9%E6%B3%95%E3%82%92%E5%A4%89%E6%9B%B4%E3%81%99%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
-移動に関する処理を従来のMove_Stateを読み取る形から直接Vector3の数値を増減させる形に変更しました。
-これにより、ボタンの同時押しによる斜め移動が可能になりました。
-

# 詳細
特記事項あれば

