### PR TITLE
133[update]ワールド選択画面 Androidの戻るボタンで戻れるようにする

### DIFF
--- a/Assets/TitleScenes/Scripts/GameSystem.cs
+++ b/Assets/TitleScenes/Scripts/GameSystem.cs
@@ -22,6 +22,17 @@ public class GameSystem : MonoBehaviour
         ModeSelectPanel.SetActive(true);
     }
 
+    private void Update()
+    {
+        if (Application.platform == RuntimePlatform.Android)
+        {
+            if (Input.GetKeyDown(KeyCode.Escape))
+            {
+                ModeSelectPanel.SetActive(false);
+            }
+        }
+    }
+
     public void OnClickWorldSelectButton(string ID)
     {
         // BlockManagerにIDを渡す

--- a/Assets/TouchScript/Examples/_misc/Textures/Icons.meta
+++ b/Assets/TouchScript/Examples/_misc/Textures/Icons.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ee4a15bf807b4f74821f1869ed9c9c4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
タスク[133](https://trello.com/c/3YXgk69M/133-%E3%83%AF%E3%83%BC%E3%83%AB%E3%83%89%E9%81%B8%E6%8A%9E%E7%94%BB%E9%9D%A2-android%E3%81%AE%E6%88%BB%E3%82%8B%E3%83%9C%E3%82%BF%E3%83%B3%E3%81%A7%E6%88%BB%E3%82%8C%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- Titleシーンでワールド選択画面を開いている時にAndroidの戻るボタンを押すと、ワールド選択画面が非表示になり初期状態に戻るようにしました。

