### PR TITLE
145[fix]2元表示中は他のボタンを表示しないようにする

### DIFF
--- a/Assets/Project/VrScenes/Scripts/InputManager.cs
+++ b/Assets/Project/VrScenes/Scripts/InputManager.cs
@@ -78,6 +78,8 @@ namespace VrScene
                     gamemanager.Back_To_Title_If_Android();
                 }
             }
+
+            NonTwoEyesModeUI.SetActive(!XRSettings.enabled);
         }
 
         public void FlyingModeCheck(bool isActive)
@@ -174,13 +176,11 @@ namespace VrScene
         public void VR_ModeOn()
         {
             XRSettings.enabled = true;
-            NonTwoEyesModeUI.SetActive(false);
         }
 
         public void VR_ModeOff()
         {
             XRSettings.enabled = false;
-            NonTwoEyesModeUI.SetActive(true);
         }
 
         public void OnClickBackToTheGame()


### PR DESCRIPTION
2元表示中は他のボタンを表示しないようにする[145](https://trello.com/c/bgUbV0kj/145-2%E5%85%83%E8%A1%A8%E7%A4%BA%E4%B8%AD%E3%81%AF%E4%BB%96%E3%81%AE%E3%83%9C%E3%82%BF%E3%83%B3%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%97%E3%81%AA%E3%81%84%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
-二眼モードから通常モードに切り替えた時にボタンが再表示されなかったバグを修正しました。

