### PR TITLE
190[fix]ブロックの選択画面のスクロールで画面が回ってしまうことがある

### DIFF
--- a/Assets/Project/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/Project/VrScenes/Scripts/PlayerManager.cs
@@ -11,6 +11,7 @@ namespace VrScene
         Rigidbody player_rigidbody;
         GameObject PlayerCamera;
         GameObject TwoEyesModeCamera;
+        public GameObject corner;
         private bool isDefault_speed = true;
         const string Stop = "Stop";
         const string Forward = "Forward";
@@ -43,7 +44,7 @@ namespace VrScene
             CheckPlayerFall();
             PlayerCamera.SetActive(!XRSettings.enabled);
             TwoEyesModeCamera.SetActive(XRSettings.enabled);
-            RotateManagerI.UpdateRotate();
+            RotateManagerI.UpdateRotate(corner.activeInHierarchy,corner.transform.position);
             if (!XRSettings.enabled)
             {
                 PlayerCamera.transform.position = this.transform.position;
@@ -120,6 +121,7 @@ namespace VrScene
             private Transform PlayerTransform;
             private Vector2 lastMousePosition;
             private bool TouchMoveEnable;
+            private bool isTouchPanel = false;
             private float CurrentRightLeftRotate;
             private float CurrentZRotate;
             private Gyroscope gyro;
@@ -135,7 +137,7 @@ namespace VrScene
                 this.gyro = Input.gyro;
             }
 
-            public void UpdateRotate()
+            public void UpdateRotate(bool isActiveColorPanel,Vector2 CornerPosition)
             {
                 /*
                  * # 各回転
@@ -156,7 +158,8 @@ namespace VrScene
                         var touch = Input.GetTouch(0);
                         if (touch.phase == TouchPhase.Began)
                         {
-                            this.OnClick(touch.position);
+                            this.OnClick(touch.position,CornerPosition,isActiveColorPanel);
+
                         } else if (touch.phase == TouchPhase.Moved)
                         {
                             this.OnMove(touch.position);
@@ -167,7 +170,8 @@ namespace VrScene
                 {
                     if (Input.GetMouseButtonDown(0))
                     {
-                        this.OnClick(Input.mousePosition);
+                        this.OnClick(Input.mousePosition,CornerPosition,isActiveColorPanel);
+
                     } else if (Input.GetMouseButton(0))
                     {
                         this.OnMove(Input.mousePosition);
@@ -176,16 +180,33 @@ namespace VrScene
                 PlayerTransform.rotation = Quaternion.AngleAxis(this.CurrentRightLeftRotate, Vector3.up); // Player本体は常に回転を固定する
             }
 
-            private void OnClick(Vector2 position)
+            private void OnClick(Vector2 position,Vector2 cornerposition,bool isActive)
             {
                 /*
                  *カーソル(or タッチ)が初めてされたときの処理
                  */
+                if (!isActive)
+                {
+                    var tappedObject = EventSystem.current.currentSelectedGameObject;
+                    this.TouchMoveEnable = tappedObject == null || tappedObject.tag == "block" || tappedObject.tag == "floor";
 
-                var tappedObject = EventSystem.current.currentSelectedGameObject;
-                this.TouchMoveEnable = tappedObject == null || tappedObject.tag == "block" ||  tappedObject.tag == "floor";
+                    this.lastMousePosition = position;
 
-                this.lastMousePosition = position;
+                    isTouchPanel = false;
+                }
+                else if (position.x < cornerposition.x || position.y > cornerposition.y)
+                {
+                    var tappedObject = EventSystem.current.currentSelectedGameObject;
+                    this.TouchMoveEnable = tappedObject == null || tappedObject.tag == "block" || tappedObject.tag == "floor";
+
+                    this.lastMousePosition = position;
+
+                    isTouchPanel = false;
+                }
+                else
+                {
+                    isTouchPanel = true;
+                }
             }
 
             private void OnMove(Vector2 position)
@@ -193,11 +214,14 @@ namespace VrScene
                 /*
                  *カーソル(or タッチ位置)が動いたときの処理
                  */
-                if (!this.TouchMoveEnable) return;
-                Vector2 vec = position - this.lastMousePosition;
-                vec = Quaternion.Euler(0, 0, this.CurrentZRotate) * vec;
-                RotateXY(new Vector3(vec.x, vec.y, 0)*10*Time.deltaTime);
-                this.lastMousePosition = position;
+                if(!isTouchPanel)
+                {
+                    if (!this.TouchMoveEnable) return;
+                    Vector2 vec = position - this.lastMousePosition;
+                    vec = Quaternion.Euler(0, 0, this.CurrentZRotate) * vec;
+                    RotateXY(new Vector3(vec.x, vec.y, 0) * 10 * Time.deltaTime);
+                    this.lastMousePosition = position;
+                }
             }
 
             private void RotateXY(Vector3 direction)

--- a/Assets/Project/VrScenes/Vr.unity
+++ b/Assets/Project/VrScenes/Vr.unity
@@ -2955,13 +2955,14 @@ RectTransform:
   - {fileID: 124262111}
   - {fileID: 1712487847}
   - {fileID: 150964170}
+  - {fileID: 2053780488}
   m_Father: {fileID: 699114735}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 205.4, y: -75.51805}
-  m_SizeDelta: {x: -311.9, y: -83.236}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -194.6, y: 108.98195}
+  m_SizeDelta: {x: 488.1, y: 285.764}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &48069405
 MonoBehaviour:
@@ -6939,7 +6940,7 @@ PrefabInstance:
     - target: {fileID: 224431128458639770, guid: 4d8c6c9fba0e46f489b21fd7d92d739d,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 224431128458639770, guid: 4d8c6c9fba0e46f489b21fd7d92d739d,
         type: 3}
@@ -38863,9 +38864,9 @@ RectTransform:
   - {fileID: 1345083672}
   - {fileID: 2042658756}
   - {fileID: 48069404}
+  - {fileID: 961816809}
   - {fileID: 1637628490}
   - {fileID: 1932141158}
-  - {fileID: 961816809}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -39927,7 +39928,7 @@ PrefabInstance:
     - target: {fileID: 224880000733725854, guid: d39ad26c554f1a04d870956f7fac6fd8,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 224880000733725854, guid: d39ad26c554f1a04d870956f7fac6fd8,
         type: 3}
@@ -53276,7 +53277,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 699114735}
-  m_RootOrder: 7
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -53482,6 +53483,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   default_move_speed: 1
   run_move_speed: 2
+  corner: {fileID: 2053780487}
   MoveRight: 0
   MoveLeft: 0
   MoveForward: 0
@@ -111858,6 +111860,80 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2052593601}
   m_Mesh: {fileID: -1854474186190359453, guid: b3862f69c9396ed45a0024ecda809a9f, type: 3}
+--- !u!1 &2053780487
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2053780488}
+  - component: {fileID: 2053780490}
+  - component: {fileID: 2053780489}
+  m_Layer: 5
+  m_Name: Corner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2053780488
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2053780487}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 48069404}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -242.3, y: 142.2}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2053780489
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2053780487}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -765806418, guid: f70555f144d8491a825f0804e09c671c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.UI.MaskableGraphic+CullStateChangedEvent, UnityEngine.UI,
+      Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+--- !u!222 &2053780490
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2053780487}
+  m_CullTransparentMesh: 0
 --- !u!1 &2054326296
 GameObject:
   m_ObjectHideFlags: 0
@@ -116347,7 +116423,7 @@ GameObject:
   - component: {fileID: 2136740897}
   m_Layer: 0
   m_Name: PlayerCamera
-  m_TagString: Untagged
+  m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/TitleScenes.meta
+++ b/Assets/TitleScenes.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 8d02ff34b43d7a142b896f05511cf604
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
タスク[190](https://trello.com/c/cjAU0p8v/190-bug-%E3%83%96%E3%83%AD%E3%83%83%E3%82%AF%E3%81%AE%E9%81%B8%E6%8A%9E%E7%94%BB%E9%9D%A2%E3%81%AE%E3%82%B9%E3%82%AF%E3%83%AD%E3%83%BC%E3%83%AB%E3%81%A7%E7%94%BB%E9%9D%A2%E3%81%8C%E5%9B%9E%E3%81%A3%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86%E3%81%93%E3%81%A8%E3%81%8C%E3%81%82%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- VrSceneの色選択画面をタップ、ドラッグした際に視点が移動してしまう問題を修正しました。