### PR TITLE
268[update]floor, 親を作ってその中に生成するようにする

### DIFF
--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -106,7 +106,7 @@ namespace VrScene
                 {
                     FloorA = (GameObject)Instantiate(Floor1, new Vector3(0.32f * i, -0.2379662f, 0.32f * j), Quaternion.identity);
                     FloorA.transform.parent = Floor.transform;
-                    FloorB = (GameObject)Instantiate(Floor2, new Vector3(0.32f * i, -0.2379662f, 0.32f * j), Quaternion.identity);
+                    FloorB = (GameObject)Instantiate(Floor2, new Vector3(0.32f * i, -0.05f, 0.32f * j), Quaternion.identity);
                     FloorB.transform.parent = Floor.transform;
                 }
             }

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -27,6 +27,7 @@ namespace VrScene
         public GameObject LoadingWindow;
         CommunicationManager CommunicationManager;
         CommunicationManager.WsClient WsClient;
+        public GameObject Floor;
 
         private void Awake()
         {
@@ -95,14 +96,18 @@ namespace VrScene
 
         private void SetFloor()
         {
+            GameObject FloorA;
+            GameObject FloorB;
             GameObject Floor1 = (GameObject)Resources.Load("Floor1");
             GameObject Floor2 = (GameObject)Resources.Load("Floor2");
             for (float i = -24; i < 24; i++)
             {
                 for (float j = -24; j < 24; j++)
                 {
-                    Instantiate(Floor1, new Vector3(0.32f * i, -0.2379662f, 0.32f * j), Quaternion.identity);
-                    Instantiate(Floor2, new Vector3(0.32f * i, -0.05f, 0.32f * j), Quaternion.identity);
+                    FloorA = (GameObject)Instantiate(Floor1, new Vector3(0.32f * i, -0.2379662f, 0.32f * j), Quaternion.identity);
+                    FloorA.transform.parent = Floor.transform;
+                    FloorB = (GameObject)Instantiate(Floor2, new Vector3(0.32f * i, -0.2379662f, 0.32f * j), Quaternion.identity);
+                    FloorB.transform.parent = Floor.transform;
                 }
             }
         }

--- a/Assets/Project/VrScenes/Vr.unity
+++ b/Assets/Project/VrScenes/Vr.unity
@@ -2671,6 +2671,7 @@ MonoBehaviour:
   BlockNumber: 0
   isRepeating: 0
   LoadingWindow: {fileID: 2042658755}
+  Floor: {fileID: 2105644942}
 --- !u!114 &784364641
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7540,6 +7541,36 @@ RectTransform:
   m_AnchoredPosition: {x: 0.000061035156, y: 0.000030517578}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2105644942
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2105644943}
+  m_Layer: 0
+  m_Name: Floor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2105644943
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2105644942}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 315.99985, y: 263.65582, z: 5.8015137}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2119897440
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Floor2.prefab
+++ b/Assets/Resources/Floor2.prefab
@@ -28,7 +28,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7570783344848714773}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.05, z: 0}
+  m_LocalPosition: {x: 0, y: -0.04, z: 0}
   m_LocalScale: {x: 0.031315207, y: 1, z: -0.032412227}
   m_Children: []
   m_Father: {fileID: 0}


### PR DESCRIPTION
タスク[268](https://trello.com/c/3YgiB1Jo/268-floor-%E8%A6%AA%E3%82%92%E4%BD%9C%E3%81%A3%E3%81%A6%E3%81%9D%E3%81%AE%E4%B8%AD%E3%81%AB%E7%94%9F%E6%88%90%E3%81%99%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- 床ブロックを生成する際、Vrシーンに新しく追加した空オブジェクトの子オブジェクトとして生成されるように変更しました。
- タスクの内容には入っていませんが、前回私がやったブロックをコードで生成するタスク以来、平面ブロックの位置がずれていた関係でプレイヤーが床に半分沈んでしまっていたので、そちらの問題も修正しました。
