### PR TITLE
ブロックの色をスマホで変えたときに変更をサーバーに保存する

### DIFF
--- a/Assets/Project/Script/CommunicationManager.cs
+++ b/Assets/Project/Script/CommunicationManager.cs
@@ -55,6 +55,14 @@ public class CommunicationManager
         return await PostRequest(apiUrl, jsonStr);
     }
 
+    public async Task<String> uploadAppliedColorRule(Rule ruleData)
+    {
+        var apiUrl = "https://" + ServerAddress + "/create_color_rule/";
+        string jsonStr = JsonUtility.ToJson(ruleData);
+        Debug.Log(jsonStr);
+        return await PostRequest(apiUrl, jsonStr);
+    }
+
     private static async Task<string> GetRequest(string url)
     {
 

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -25,7 +25,7 @@ namespace VrScene
         Toggle PlayBackButton;
         GameManager GameManager;
         public GameObject LoadingWindow;
-        CommunicationManager CommunicationManager;
+        public CommunicationManager CommunicationManager;
         CommunicationManager.WsClient WsClient;
         public GameObject Floor;
 

--- a/Assets/Project/VrScenes/Scripts/ColorChangePanel.cs
+++ b/Assets/Project/VrScenes/Scripts/ColorChangePanel.cs
@@ -117,6 +117,7 @@ namespace VrScene
             Toggle checkToggle = toggleGroup.ActiveToggles().FirstOrDefault();
             string toMaterialName = checkToggle.transform.Find("MaterialNameLabel").gameObject.GetComponent<Text>().text.Replace("Color", "");
             targetBlock.GetComponent<Block>().SetColor(toMaterialName);
+            colorChangePanel.SetActive(false);
         }
 
         public void OnClickAllColorChangeButton()
@@ -125,6 +126,7 @@ namespace VrScene
             string toMaterialName = checkToggle.transform.Find("MaterialNameLabel").gameObject.GetComponent<Text>().text;
             Material toMaterial = contentMaterials.Find(material => material.name == toMaterialName);
             blockManager.ApplyColorRules(blockManager.MakeColorRules("color", targetBlock.GetComponent<Renderer>().material.name.Replace("Color", ""), toMaterial.name.Replace("Color", "")));
+            colorChangePanel.SetActive(false);
         }
 
         public void OnClickCancelButton()

--- a/Assets/Project/VrScenes/Scripts/ColorChangePanel.cs
+++ b/Assets/Project/VrScenes/Scripts/ColorChangePanel.cs
@@ -10,18 +10,20 @@ namespace VrScene
     public class ColorChangePanel : MonoBehaviour
     {
         BlockManager blockManager;
-        CommunicationManager communicationManager = new CommunicationManager();
+        CommunicationManager communicationManager;
         [SerializeField] public GameObject panelPref;
         private List<Material> contentMaterials = new List<Material>();
         public GameObject contentObject;
         public GameObject colorChangePanel;
         private ToggleGroup toggleGroup;
         private GameObject targetBlock;
+        private Block targetBlockData;
         public GameObject lightUpObject = null;
 
         private void Awake()
         {
             blockManager = GameObject.Find("GameSystem").GetComponent<BlockManager>();
+            communicationManager = blockManager.CommunicationManager;
         }
 
         public void OnEnable()
@@ -45,6 +47,7 @@ namespace VrScene
         public void SetupColorChangePanel(GameObject targetObject)
         {
             targetBlock = targetObject;
+            targetBlockData = targetBlock.GetComponent<Block>();
             SetColorPanel(targetBlock);
         }
 
@@ -116,7 +119,6 @@ namespace VrScene
 
         public void OnClickChangeButton()
         {
-            Block targetBlockData = targetBlock.GetComponent<Block>();
             Toggle checkToggle = toggleGroup.ActiveToggles().FirstOrDefault();
             string toMaterialName = checkToggle.transform.Find("MaterialNameLabel").gameObject.GetComponent<Text>().text.Replace("Color", "");
             string originColorID = targetBlockData.colorID;
@@ -128,10 +130,10 @@ namespace VrScene
         {
             Toggle checkToggle = toggleGroup.ActiveToggles().FirstOrDefault();
             string toMaterialName = checkToggle.transform.Find("MaterialNameLabel").gameObject.GetComponent<Text>().text;
+            string originColorID = targetBlockData.colorID;
             Material toMaterial = contentMaterials.Find(material => material.name == toMaterialName);
             blockManager.ApplyColorRules(blockManager.MakeColorRules("color", targetBlock.GetComponent<Renderer>().material.name.Replace("Color", ""), toMaterial.name.Replace("Color", "")));
-            colorChangePanel.SetActive(false);
-            //StartCoroutine(UploadAppliedColorRule("color", null, ));
+            StartCoroutine(UploadAppliedColorRule("color", null, originColorID, targetBlockData.colorID, BlockManager.WorldID));
         }
 
         public void OnClickCancelButton()


### PR DESCRIPTION
ブロックの色をスマホで変えたときに変更をサーバーに保存する[191](https://trello.com/c/4DM7Jb53/191-%E3%83%96%E3%83%AD%E3%83%83%E3%82%AF%E3%81%AE%E8%89%B2%E3%82%92%E3%82%B9%E3%83%9E%E3%83%9B%E3%81%A7%E5%A4%89%E3%81%88%E3%81%9F%E3%81%A8%E3%81%8D%E3%81%AB%E5%A4%89%E6%9B%B4%E3%82%92%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%81%AB%E4%BF%9D%E5%AD%98%E3%81%99%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- colorchangepanel.csをいじった
-
-

# 詳細
特記事項あれば

