### PR TITLE
283[update]床の高さが間違っている

### DIFF
--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -136,9 +136,9 @@ namespace VrScene
             {
                 for (float j = -24; j < 24; j++)
                 {
-                    FloorA = (GameObject)Instantiate(Floor1, new Vector3(0.32f * i, -0.2379662f, 0.32f * j), Quaternion.identity);
+                    FloorA = (GameObject)Instantiate(Floor1, new Vector3(0.32f * i, -0.0f, 0.32f * j), Quaternion.identity);
                     FloorA.transform.parent = Floor.transform;
-                    FloorB = (GameObject)Instantiate(Floor2, new Vector3(0.32f * i, -0.05f, 0.32f * j), Quaternion.identity);
+                    FloorB = (GameObject)Instantiate(Floor2, new Vector3(0.32f * i, 0.19f, 0.32f * j), Quaternion.identity);
                     FloorB.transform.parent = Floor.transform;
                 }
             }

--- a/Assets/Project/VrScenes/Scripts/PlayerManager.cs
+++ b/Assets/Project/VrScenes/Scripts/PlayerManager.cs
@@ -116,6 +116,9 @@ namespace VrScene
         private void RespawnPlayer()
         {
             transform.position = Vector3.zero;
+            Vector3 pos = transform.position;
+            pos.y = 1.0f;
+            transform.position = pos;
         }
 
         private void CheckPlayerFall()

--- a/Assets/Project/VrScenes/Vr.unity
+++ b/Assets/Project/VrScenes/Vr.unity
@@ -7885,7 +7885,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2105644942}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 315.99985, y: 263.65582, z: 5.8015137}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Resources/Floor1.prefab
+++ b/Assets/Resources/Floor1.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 9104238461596996451}
   - component: {fileID: 217235030257117525}
   - component: {fileID: 5782427791839778220}
-  - component: {fileID: 5189159953824670071}
+  - component: {fileID: -1123095817969121215}
   m_Layer: 0
   m_Name: Floor1
   m_TagString: Untagged
@@ -78,8 +78,8 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!64 &5189159953824670071
-MeshCollider:
+--- !u!65 &-1123095817969121215
+BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -88,7 +88,6 @@ MeshCollider:
   m_Material: {fileID: 0}
   m_IsTrigger: 1
   m_Enabled: 1
-  serializedVersion: 3
-  m_Convex: 1
-  m_CookingOptions: 14
-  m_Mesh: {fileID: -1854474186190359453, guid: b3862f69c9396ed45a0024ecda809a9f, type: 3}
+  serializedVersion: 2
+  m_Size: {x: 0.4, y: 0.4708318, z: 0.4}
+  m_Center: {x: 0, y: 0.03541591, z: 0}

--- a/Assets/Resources/Floor2.prefab
+++ b/Assets/Resources/Floor2.prefab
@@ -29,7 +29,7 @@ Transform:
   m_GameObject: {fileID: 7570783344848714773}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: -0.04, z: 0}
-  m_LocalScale: {x: 0.031315207, y: 1, z: -0.032412227}
+  m_LocalScale: {x: 0.032, y: 1, z: -0.032}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0


### PR DESCRIPTION
タスク[283](https://trello.com/c/t8IURwtB/283-%E5%BA%8A%E3%81%AE%E9%AB%98%E3%81%95%E3%81%8C%E9%96%93%E9%81%95%E3%81%A3%E3%81%A6%E3%81%84%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- 床の高さをy=0に変更しました。
- リスポーンする高度を床の高度に合わせて変更しました。
- Block2(平面オブジェクト)の面積を0.32x0.32(ブロックの面積と同じ)に微調整しました。