### PR TITLE
マージしたときマージした部分の床を生成するようにする

### DIFF
--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -107,6 +107,8 @@ namespace VrScene
 
             if (GameManager.Mode == "PlayBack") InputManager.PlayBackModeUI.SetActive(true);
             LoadingWindow.SetActive(false);
+
+            GameObject.Find("Player").GetComponent<PlayerManager>().Flying(false);
         }
         
         public void StopPlayback()

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -138,13 +138,14 @@ namespace VrScene
             float minX = 0.0f;
             float maxZ = 0.0f;
             float minZ = 0.0f;
+            float extensionFloor = 48.0f;
             for (int i = 0; i < Blocks.Count; i++)
             {
                 Block block = Blocks[i];
-                if (maxX <= block.x) maxX = block.x;
-                if (minX >= block.x) minX = block.x;
-                if (maxZ <= block.z) maxZ = block.z;
-                if (minZ >= block.z) minZ = block.z;
+                if (maxX <= block.x) maxX = block.x + extensionFloor;
+                if (minX >= block.x) minX = block.x - extensionFloor;
+                if (maxZ <= block.z) maxZ = block.z + extensionFloor;
+                if (minZ >= block.z) minZ = block.z - extensionFloor;
             }
 
             for (float i = minX; i <= maxX; i++)

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -142,15 +142,15 @@ namespace VrScene
             for (int i = 0; i < Blocks.Count; i++)
             {
                 Block block = Blocks[i];
-                if (maxX <= block.x) maxX = block.x + extensionFloor;
-                if (minX >= block.x) minX = block.x - extensionFloor;
-                if (maxZ <= block.z) maxZ = block.z + extensionFloor;
-                if (minZ >= block.z) minZ = block.z - extensionFloor;
+                if (maxX <= block.x) maxX = block.x;
+                if (minX >= block.x) minX = block.x;
+                if (maxZ <= block.z) maxZ = block.z;
+                if (minZ >= block.z) minZ = block.z;
             }
 
-            for (float i = minX; i <= maxX; i++)
+            for (float i = minX - extensionFloor; i <= maxX + extensionFloor; i++)
             {
-                for (float j = minZ; j <= maxZ; j++)
+                for (float j = minZ - extensionFloor; j <= maxZ + extensionFloor; j++)
                 {
                     FloorA = (GameObject)Instantiate(Floor1, new Vector3(0.32f * i, -0.0f, 0.32f * j), Quaternion.identity);
                     FloorA.transform.parent = Floor.transform;

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -80,7 +80,6 @@ namespace VrScene
             seekbarSlider = InputManager.seekbarSlider;
             PlayBackButton = InputManager.PlayBackButton;
             GameManager = GameSystem.GetComponent<GameManager>();
-            SetFloor();
             StartCoroutine("FetchData");
         }
 
@@ -103,6 +102,8 @@ namespace VrScene
             yield return new WaitUntil(() => fetchColorRulesTask.IsCompleted);
             this.ColorRules = fetchColorRulesTask.Result;
             this.ColorRules.ForEach(this.ApplyColorRule);
+
+            SetFloor();
 
             if (GameManager.Mode == "PlayBack") InputManager.PlayBackModeUI.SetActive(true);
             LoadingWindow.SetActive(false);
@@ -132,9 +133,23 @@ namespace VrScene
             GameObject FloorB;
             GameObject Floor1 = (GameObject)Resources.Load("Floor1");
             GameObject Floor2 = (GameObject)Resources.Load("Floor2");
-            for (float i = -24; i < 24; i++)
+
+            float maxX = 0.0f;
+            float minX = 0.0f;
+            float maxZ = 0.0f;
+            float minZ = 0.0f;
+            for (int i = 0; i < Blocks.Count; i++)
             {
-                for (float j = -24; j < 24; j++)
+                Block block = Blocks[i];
+                if (maxX <= block.x) maxX = block.x;
+                if (minX >= block.x) minX = block.x;
+                if (maxZ <= block.z) maxZ = block.z;
+                if (minZ >= block.z) minZ = block.z;
+            }
+
+            for (float i = minX; i <= maxX; i++)
+            {
+                for (float j = minZ; j <= maxZ; j++)
                 {
                     FloorA = (GameObject)Instantiate(Floor1, new Vector3(0.32f * i, -0.0f, 0.32f * j), Quaternion.identity);
                     FloorA.transform.parent = Floor.transform;

--- a/Assets/Project/VrScenes/Vr.unity
+++ b/Assets/Project/VrScenes/Vr.unity
@@ -3515,7 +3515,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963194225}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: 0}
+  m_LocalPosition: {x: 0, y: 20, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2136740894}
@@ -3558,7 +3558,7 @@ Rigidbody:
   m_Mass: 1
   m_Drag: 0
   m_AngularDrag: 0.05
-  m_UseGravity: 1
+  m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0

--- a/Assets/Simple Buttons/Icons.meta
+++ b/Assets/Simple Buttons/Icons.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3c99566ad6e53354bb7cb62ca4c17432
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/TitleScenes/Scripts.meta
+++ b/Assets/TitleScenes/Scripts.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 982ba65442526694882a9408651da14b
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
マージしたときマージした部分の床を生成するようにする[265](https://trello.com/c/znHWh5T1/265-%E3%83%9E%E3%83%BC%E3%82%B8%E3%81%97%E3%81%9F%E3%81%A8%E3%81%8D%E3%83%9E%E3%83%BC%E3%82%B8%E3%81%97%E3%81%9F%E9%83%A8%E5%88%86%E3%81%AE%E5%BA%8A%E3%82%92%E7%94%9F%E6%88%90%E3%81%99%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- blockの座標に合わせてfloorを配置するようにした
- playerをy=20でスポーンさせるようにした
-

# 詳細
特記事項あれば

