### PR TITLE
[fix] 2眼VRの状態で起動してしまう問題

### DIFF
--- a/Assets/Project/TitleScenes/Scripts/GameSystem.cs
+++ b/Assets/Project/TitleScenes/Scripts/GameSystem.cs
@@ -28,6 +28,7 @@ namespace TitleScene
 
         private void Awake()
         {
+            XRSettings.LoadDeviceByName("Cardboard");
             XRSettings.enabled = false;
         }
 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -417,6 +417,7 @@ PlayerSettings:
   - m_BuildTarget: Android
     m_Enabled: 1
     m_Devices:
+    - None
     - cardboard
   m_BuildTargetEnableVuforiaSettings: []
   openGLRequireES31: 0


### PR DESCRIPTION
タスク[172](https://trello.com/c/MFmV9Cx9/172-title%E7%94%BB%E9%9D%A2%E3%81%A72%E7%9C%BCvr%E3%81%AB%E3%81%AA%E3%81%A3%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86)に対するPRです。


# 主な変更、追加箇所  
-
-
-

# 詳細
特記事項あれば

