### PR TITLE
298 [fix] 2眼VRにしたときに近くの物が透けてしまう問題

### DIFF
--- a/Assets/Project/VrScenes/Vr.unity
+++ b/Assets/Project/VrScenes/Vr.unity
@@ -4526,7 +4526,7 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
+  near clip plane: 0.01
   far clip plane: 1000
   field of view: 60
   orthographic: 0


### PR DESCRIPTION
タスク[298](https://trello.com/c/zyrmg7zV/298-vr%E3%81%A7%E8%BF%91%E3%81%8F%E3%81%AE%E3%82%82%E3%81%AE%E3%81%8C%E9%80%8F%E3%81%91%E3%81%A6%E3%81%97%E3%81%BE%E3%81%86%E5%95%8F%E9%A1%8C)に対するPRです。


# 主な変更、追加箇所  
-
-
-

# 詳細
特記事項あれば

