### PR TITLE
[fix]道路が浮いてる

### DIFF
--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -385,9 +385,9 @@ namespace VrScene
                                 // 道路を生成
                                 GameObject patternObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
                                 patternObject.transform.position = new Vector3(
-                                    (nearestBlock.x + farthestBlock.x) * X_RATIO / 2,
-                                    (nearestBlock.y + farthestBlock.y) * Y_RATIO / 2,
-                                    (nearestBlock.z + farthestBlock.z) * Z_RATIO / 2
+                                    (nearestBlock.x + farthestBlock.x) * X_RATIO / 2.0f,
+                                    (nearestBlock.y + farthestBlock.y) * Y_RATIO / 4.0f,
+                                    (nearestBlock.z + farthestBlock.z) * Z_RATIO / 2.0f
                                 );
                                 patternObject.name = patternGroupId;
                                 patternObject.transform.localScale = new Vector3(width, height, depth);
@@ -402,9 +402,9 @@ namespace VrScene
                                 // 道路を生成
                                 GameObject patternObject = GameObject.CreatePrimitive(PrimitiveType.Cube);
                                 patternObject.transform.position = new Vector3(
-                                    (nearestBlock.x + farthestBlock.x) * X_RATIO / 2,
-                                    (nearestBlock.y + farthestBlock.y) * Y_RATIO / 2,
-                                    (nearestBlock.z + farthestBlock.z) * Z_RATIO / 2
+                                    (nearestBlock.x + farthestBlock.x) * X_RATIO / 2.0f,
+                                    (nearestBlock.y + farthestBlock.y) * Y_RATIO / 4.0f,
+                                    (nearestBlock.z + farthestBlock.z) * Z_RATIO / 2.0f
                                 );
                                 patternObject.name = patternGroupId;
                                 patternObject.transform.localScale = new Vector3(width, height, depth);


### PR DESCRIPTION
タスク[326](https://trello.com/c/InAUEIPg/326-%E3%83%91%E3%82%BF%E3%83%BC%E3%83%B3%E8%AA%8D%E8%AD%98%E9%81%93%E8%B7%AF-%E6%B5%AE%E3%81%84%E3%81%A6%E3%82%8B)に対するPRです。


# 主な変更、追加箇所  
- 割り算で小数点以下が切り捨てされる実装になっていたので直した
