### PR TITLE
292[update]再生、若干ラグがある

### DIFF
--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -121,12 +121,26 @@ namespace VrScene
             seekbarSlider.value = seekbarSlider.maxValue;
             InputManager.PlayBackModeUI.SetActive(false);
             isRepeating = false;
+            for (int i = 0; i < BlocksCount; i++)
+            {
+                Blocks[i].SetActive(true);
+                Vector3 pos = Blocks[i].transform.position;
+                pos.y = NeutralPositions[i];
+                Blocks[i].transform.position = pos;
+            }
         }
         public void StartPlayback()
         {
             GameManager.Mode = "PlayBack";
             InputManager.PlayBackModeUI.SetActive(true);
             InputManager.ViewModeUI.SetActive(false);
+            for (int i =0;i<BlocksCount;i++)
+            {
+                Blocks[i].SetActive(false);
+                Vector3 pos = Blocks[i].transform.position;
+                pos.y = NeutralPositions[i]+20;
+                Blocks[i].transform.position = pos;
+            }
         }
 
         void InitialPlacement(List<BlockInfo> blocksInfo)
@@ -238,6 +252,20 @@ namespace VrScene
             ReplacePatternWithObject();
         }
 
+        public void BlockSkip(int slider,bool SkipOrBack)
+        {
+            Vector3 pos = Blocks[slider].transform.position;
+            if (SkipOrBack)
+            {
+                pos.y = NeutralPositions[slider];
+            }
+            else
+            {
+                pos.y = NeutralPositions[slider] + 20;
+            }
+            Blocks[slider].transform.position = pos;
+        }
+
         public async void RepeatPlaceBlocks()
         {
             isRepeating = true;
@@ -246,7 +274,12 @@ namespace VrScene
             {
                 if (seekbarSlider.value == seekbarSlider.maxValue)
                 {
+                    while (Blocks[(int)seekbarSlider.maxValue-1].transform.position.y!=NeutralPositions[(int)seekbarSlider.maxValue-1])
+                    {
+                        await Task.Delay(1);
+                    }
                     await Task.Delay(3000);
+                    StartPlayback();
                     break;
                 }
                 int FirstBlockTime = (int)Blocks[(int)seekbarSlider.value].time;
@@ -254,7 +287,7 @@ namespace VrScene
                 seekbarSlider.value++;
                 if(seekbarSlider.value != seekbarSlider.maxValue)
                 {
-                    if ((FirstBlockTime - (int)Blocks[(int)seekbarSlider.value].time) * (FirstBlockTime - (int)Blocks[(int)seekbarSlider.value].time) >= 25)
+                    if ((int)Blocks[(int)seekbarSlider.value].time - FirstBlockTime > 1)
                         await Task.Delay(1000);
                 }
             }
@@ -270,7 +303,7 @@ namespace VrScene
         async void FallingBlock(int i)
         {
             float Accel = 0f;
-            for (float j = NeutralPositions[i]+20; j > NeutralPositions[i]; j -= Accel)
+            for (float j = Blocks[i].transform.position.y; j > NeutralPositions[i]; j -= Accel)
             {
                 Vector3 pos = Blocks[i].transform.position;
                 pos.y = j;

--- a/Assets/Project/VrScenes/Scripts/InputManager.cs
+++ b/Assets/Project/VrScenes/Scripts/InputManager.cs
@@ -150,11 +150,13 @@ namespace VrScene
         public void OnClickAdvanceSkipButton()
         {
             seekbarSlider.value++;
+            BlockManager.BlockSkip((int)seekbarSlider.value-1,true);
         }
 
         public void OnClickBackSkipButton()
         {
             seekbarSlider.value--;
+            BlockManager.BlockSkip((int)seekbarSlider.value+1, false);
         }
 
         // GeneralMenu

--- a/Assets/Resources/RoadMaterialImage.png.meta
+++ b/Assets/Resources/RoadMaterialImage.png.meta
@@ -1,0 +1,90 @@
+fileFormatVersion: 2
+guid: 3b14270660f1bf5458cc2932e6f3f66e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 10
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: -1
+    aniso: -1
+    mipBias: -100
+    wrapU: -1
+    wrapV: -1
+    wrapW: -1
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  platformSettings:
+  - serializedVersion: 2
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SocialConnector/Plugins/Android.meta
+++ b/Assets/SocialConnector/Plugins/Android.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3f1797cd2bf7444459deaa2877867e9d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
タスク[292](TrelloのタスクURL)に対するPRです。


# 主な変更、追加箇所  
- 再生モードをオンにするとブロックがあらかじめ落下開始地点にテレポートするようになりました。(若干のラグ軽減)
- 再生モードでブロックが落下しきるまで再生が続くようになりました
- 同時に落下するブロックの範囲を±1秒に変更しました。(現実でブロックを置いて作成したマップでの動作は未確認なので要検証)
# 詳細
- 同時に落下するブロックを1つの親オブジェクトにまとめることが出来ればさらにラグを改善できますが、当日までに間に合うかどうかが怪しいので一旦現状進めた部分だけマージをお願いします。

