### PR TITLE
265[update]マージしたときマージした部分の床を生成するようにする ＋ 見えない壁

### DIFF
--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -34,6 +34,7 @@ namespace VrScene
         private float Y_RATIO = 0.384f;
         private float Z_RATIO = 0.32f;
         public GameObject Floor;
+        public GameObject Walls;
         public List<float> HighestPositions = new List<float>() {0, 0, 0, 0};//{一番大きいx, 一番小さいx, 一番大きいz, 一番小さいz}
         private void Awake()
         {
@@ -112,6 +113,7 @@ namespace VrScene
 
             if (GameManager.Mode == "PlayBack") InputManager.PlayBackModeUI.SetActive(true);
             SetFloor();
+            SetWall();
             LoadingWindow.SetActive(false);
         }
         
@@ -154,7 +156,6 @@ namespace VrScene
 
             Vector3 CornerPosition = new Vector3(HighestPositions[0], 0, HighestPositions[2]);
             Vector3 AnotherCornerPosition = new Vector3(HighestPositions[1], 0, HighestPositions[3]);
-            Debug.Log(CornerPosition.x + ":" + CornerPosition.z + ":" + AnotherCornerPosition.x + ":" + AnotherCornerPosition.z);
             GameObject FloorObj = Resources.Load("Floor_10") as GameObject;
 
             if (IsMerge)
@@ -180,6 +181,53 @@ namespace VrScene
                 }
             }
             Floor.transform.position = new Vector3(3.2f, 0, 3.2f);
+        }
+
+        private void SetWall()
+        {
+            GameObject Wall;
+            GameObject WallObj = Resources.Load("Wall") as GameObject;
+
+            Vector3 CornerPosition = new Vector3(HighestPositions[0], 0, HighestPositions[2]);
+            Vector3 AnotherCornerPosition = new Vector3(HighestPositions[1], 0, HighestPositions[3]);
+
+            if (IsMerge)
+            {
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(CornerPosition.x + 6.4f, 0, 0), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(0.1f, 1000, 1000);
+                Wall.transform.parent = Walls.transform;
+
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(AnotherCornerPosition.x + -6.4f, 0, 0), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(0.1f, 1000, 1000);
+                Wall.transform.parent = Walls.transform;
+
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(0, 0, CornerPosition.z + 6.4f), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(1000, 1000, 0.1f);
+                Wall.transform.parent = Walls.transform;
+
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(0, 0, AnotherCornerPosition.z - 6.4f), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(1000, 1000, 0.1f);
+                Wall.transform.parent = Walls.transform;
+            }
+            else
+            {
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(4 * 3.2f + 3.2f, 0, 0), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(0.1f, 1000, 1000);
+                Wall.transform.parent = Walls.transform;
+
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(-4 * 3.2f, 0, 0), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(0.1f, 1000, 1000);
+                Wall.transform.parent = Walls.transform;
+
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(0, 0, 4 * 3.2f + 3.2f), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(1000, 1000, 0.1f);
+                Wall.transform.parent = Walls.transform;
+
+                Wall = (GameObject)Instantiate(WallObj, new Vector3(0, 0, -4 * 3.2f), Quaternion.identity);
+                Wall.transform.localScale = new Vector3(1000, 1000, 0.1f);
+                Wall.transform.parent = Walls.transform;
+            }
+            Walls.transform.position = new Vector3(-3.2f, 0 ,-3.2f);
         }
 
         private void AddBlock(BlockInfo blockInfo)

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -152,16 +152,30 @@ namespace VrScene
         {
             GameObject FloorA;
 
-            Vector3 CornerPosition = new Vector3(HighestPositions[1], 0, HighestPositions[3]);
-            Vector3 AnotherCornerPosition = new Vector3(HighestPositions[2], 0, HighestPositions[4]);
+            Vector3 CornerPosition = new Vector3(HighestPositions[0], 0, HighestPositions[1]);
+            Vector3 AnotherCornerPosition = new Vector3(HighestPositions[2], 0, HighestPositions[3]);
             GameObject FloorObj = Resources.Load("Floor_10") as GameObject;
 
-            for (float i = AnotherCornerPosition.x - 3.2f; i < CornerPosition.x + 3.2f; i += 3.2f)
+            if (IsMerge)
             {
-                for (float j = AnotherCornerPosition.z + 3.2f; j < CornerPosition.z + 3.2f; j += 3.2f)
+                for (float i = AnotherCornerPosition.x - 3.2f; i < CornerPosition.x + 3.2f; i += 3.2f)
                 {
-                    FloorA = (GameObject)Instantiate(FloorObj, new Vector3(i, -0.0f, j), Quaternion.identity);
-                    FloorA.transform.parent = Floor.transform;
+                    for (float j = AnotherCornerPosition.z + 3.2f; j < CornerPosition.z + 3.2f; j += 3.2f)
+                    {
+                        FloorA = (GameObject)Instantiate(FloorObj, new Vector3(i, -0.0f, j), Quaternion.identity);
+                        FloorA.transform.parent = Floor.transform;
+                    }
+                }
+            }
+            else
+            {
+                for (float i = -4; i < 4; i++)
+                {
+                    for (float j = -4; j < 4; j++)
+                    {
+                        FloorA = (GameObject)Instantiate(FloorObj, new Vector3(10 * 0.32f * i, -0.0f, 10 * 0.32f * j), Quaternion.identity);
+                        FloorA.transform.parent = Floor.transform;
+                    }
                 }
             }
         }
@@ -179,10 +193,10 @@ namespace VrScene
                 if (GameManager.Mode == "PlayBack") block.SetActive(false);
                 this.Blocks.Add(block);
                 NeutralPositions.Add(Blocks[BlocksCount].transform.position.y);
-                if (block.transform.position.x > HighestPositions[1]) HighestPositions[1] = block.transform.position.x;
-                if (block.transform.position.x < HighestPositions[2]) HighestPositions[2] = block.transform.position.x;
-                if (block.transform.position.z > HighestPositions[3]) HighestPositions[3] = block.transform.position.x;
-                if (block.transform.position.z < HighestPositions[4]) HighestPositions[4] = block.transform.position.x;
+                if (block.transform.position.x > HighestPositions[0]) HighestPositions[0] = block.transform.position.x;
+                if (block.transform.position.x < HighestPositions[1]) HighestPositions[1] = block.transform.position.x;
+                if (block.transform.position.z > HighestPositions[2]) HighestPositions[2] = block.transform.position.x;
+                if (block.transform.position.z < HighestPositions[3]) HighestPositions[3] = block.transform.position.x;
                 Debug.Log(HighestPositions);
                 this.BlocksCount += 1;
             }

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -86,7 +86,6 @@ namespace VrScene
             seekbarSlider = InputManager.seekbarSlider;
             PlayBackButton = InputManager.PlayBackButton;
             GameManager = GameSystem.GetComponent<GameManager>();
-            SetFloor();
             StartCoroutine("FetchData");
         }
 
@@ -112,6 +111,7 @@ namespace VrScene
             this.ColorRules.ForEach(this.ApplyColorRule);
 
             if (GameManager.Mode == "PlayBack") InputManager.PlayBackModeUI.SetActive(true);
+            SetFloor();
             LoadingWindow.SetActive(false);
         }
         
@@ -152,15 +152,16 @@ namespace VrScene
         {
             GameObject FloorA;
 
-            Vector3 CornerPosition = new Vector3(HighestPositions[0], 0, HighestPositions[1]);
-            Vector3 AnotherCornerPosition = new Vector3(HighestPositions[2], 0, HighestPositions[3]);
+            Vector3 CornerPosition = new Vector3(HighestPositions[0], 0, HighestPositions[2]);
+            Vector3 AnotherCornerPosition = new Vector3(HighestPositions[1], 0, HighestPositions[3]);
+            Debug.Log(CornerPosition.x + ":" + CornerPosition.z + ":" + AnotherCornerPosition.x + ":" + AnotherCornerPosition.z);
             GameObject FloorObj = Resources.Load("Floor_10") as GameObject;
 
             if (IsMerge)
             {
-                for (float i = AnotherCornerPosition.x - 3.2f; i < CornerPosition.x + 3.2f; i += 3.2f)
+                for (float i = AnotherCornerPosition.x - 6.4f; i < CornerPosition.x + 6.4f; i += 3.2f)
                 {
-                    for (float j = AnotherCornerPosition.z + 3.2f; j < CornerPosition.z + 3.2f; j += 3.2f)
+                    for (float j = AnotherCornerPosition.z - 6.4f; j < CornerPosition.z + 6.4f; j += 3.2f)
                     {
                         FloorA = (GameObject)Instantiate(FloorObj, new Vector3(i, -0.0f, j), Quaternion.identity);
                         FloorA.transform.parent = Floor.transform;
@@ -178,6 +179,7 @@ namespace VrScene
                     }
                 }
             }
+            Floor.transform.position = new Vector3(3.2f, 0, 3.2f);
         }
 
         private void AddBlock(BlockInfo blockInfo)
@@ -195,9 +197,8 @@ namespace VrScene
                 NeutralPositions.Add(Blocks[BlocksCount].transform.position.y);
                 if (block.transform.position.x > HighestPositions[0]) HighestPositions[0] = block.transform.position.x;
                 if (block.transform.position.x < HighestPositions[1]) HighestPositions[1] = block.transform.position.x;
-                if (block.transform.position.z > HighestPositions[2]) HighestPositions[2] = block.transform.position.x;
-                if (block.transform.position.z < HighestPositions[3]) HighestPositions[3] = block.transform.position.x;
-                Debug.Log(HighestPositions);
+                if (block.transform.position.z > HighestPositions[2]) HighestPositions[2] = block.transform.position.z;
+                if (block.transform.position.z < HighestPositions[3]) HighestPositions[3] = block.transform.position.z;
                 this.BlocksCount += 1;
             }
             else

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -34,7 +34,7 @@ namespace VrScene
         private float Y_RATIO = 0.384f;
         private float Z_RATIO = 0.32f;
         public GameObject Floor;
-
+        public List<float> HighestPositions = new List<float>() {0, 0, 0, 0};//{一番大きいx, 一番小さいx, 一番大きいz, 一番小さいz}
         private void Awake()
         {
             CommunicationManager = new CommunicationManager();
@@ -178,6 +178,11 @@ namespace VrScene
                 if (GameManager.Mode == "PlayBack") block.SetActive(false);
                 this.Blocks.Add(block);
                 NeutralPositions.Add(Blocks[BlocksCount].transform.position.y);
+                if (block.transform.position.x > HighestPositions[1]) HighestPositions[1] = block.transform.position.x;
+                if (block.transform.position.x < HighestPositions[2]) HighestPositions[2] = block.transform.position.x;
+                if (block.transform.position.z > HighestPositions[3]) HighestPositions[3] = block.transform.position.x;
+                if (block.transform.position.z < HighestPositions[4]) HighestPositions[4] = block.transform.position.x;
+                Debug.Log(HighestPositions);
                 this.BlocksCount += 1;
             }
             else

--- a/Assets/Project/VrScenes/Scripts/BlockManager.cs
+++ b/Assets/Project/VrScenes/Scripts/BlockManager.cs
@@ -151,15 +151,16 @@ namespace VrScene
         private void SetFloor()
         {
             GameObject FloorA;
-            
-            int extantionFloor = 4;
+
+            Vector3 CornerPosition = new Vector3(HighestPositions[1], 0, HighestPositions[3]);
+            Vector3 AnotherCornerPosition = new Vector3(HighestPositions[2], 0, HighestPositions[4]);
             GameObject FloorObj = Resources.Load("Floor_10") as GameObject;
 
-            for (float i = -1*extantionFloor; i < extantionFloor; i++)
+            for (float i = AnotherCornerPosition.x - 3.2f; i < CornerPosition.x + 3.2f; i += 3.2f)
             {
-                for (float j = -1*extantionFloor; j < extantionFloor; j++)
+                for (float j = AnotherCornerPosition.z + 3.2f; j < CornerPosition.z + 3.2f; j += 3.2f)
                 {
-                    FloorA = (GameObject)Instantiate(FloorObj, new Vector3(10*0.32f * i, -0.0f, 10*0.32f * j), Quaternion.identity);
+                    FloorA = (GameObject)Instantiate(FloorObj, new Vector3(i, -0.0f, j), Quaternion.identity);
                     FloorA.transform.parent = Floor.transform;
                 }
             }

--- a/Assets/Project/VrScenes/Vr.unity
+++ b/Assets/Project/VrScenes/Vr.unity
@@ -2845,6 +2845,12 @@ MonoBehaviour:
   isRepeating: 0
   LoadingWindow: {fileID: 2042658755}
   Floor: {fileID: 2105644942}
+  Walls: {fileID: 2017114071}
+  HighestPositions:
+  - 0
+  - 0
+  - 0
+  - 0
 --- !u!114 &784364641
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7445,6 +7451,36 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2014737507}
   m_CullTransparentMesh: 1
+--- !u!1 &2017114071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2017114072}
+  m_Layer: 0
+  m_Name: Walls
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2017114072
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2017114071}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2028061892
 GameObject:
   m_ObjectHideFlags: 0
@@ -8190,6 +8226,98 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2106412597
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2106412601}
+  - component: {fileID: 2106412600}
+  - component: {fileID: 2106412599}
+  - component: {fileID: 2106412598}
+  m_Layer: 0
+  m_Name: PlayerSpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!64 &2106412598
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106412597}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Convex: 0
+  m_CookingOptions: 14
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2106412599
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106412597}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 710e5fb75cf29584787eb82bfd3e746b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &2106412600
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106412597}
+  m_Mesh: {fileID: 10209, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2106412601
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2106412597}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2119897440
 GameObject:

--- a/Assets/Resources/Wall.prefab
+++ b/Assets/Resources/Wall.prefab
@@ -1,0 +1,93 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &6149514290857853131
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6149514290857853175}
+  - component: {fileID: 6149514290857853174}
+  - component: {fileID: 6149514290857853173}
+  - component: {fileID: 6149514290857853172}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &6149514290857853175
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6149514290857853131}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1000, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &6149514290857853174
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6149514290857853131}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &6149514290857853173
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6149514290857853131}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 710e5fb75cf29584787eb82bfd3e746b, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!65 &6149514290857853172
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6149514290857853131}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Resources/Wall.prefab.meta
+++ b/Assets/Resources/Wall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c4829930b9198604b857b536b27bff97
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/WallMaterial.mat
+++ b/Assets/Resources/WallMaterial.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: WallMaterial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: _ALPHABLEND_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: 3000
+  stringTagMap:
+    RenderType: Transparent
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 10
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 2
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 5
+    - _UVSec: 0
+    - _ZWrite: 0
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 0}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Resources/WallMaterial.mat.meta
+++ b/Assets/Resources/WallMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 710e5fb75cf29584787eb82bfd3e746b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
マージしたときマージした部分の床を生成するようにする ＋ 見えない壁[265](https://trello.com/c/znHWh5T1/265-%E3%83%9E%E3%83%BC%E3%82%B8%E3%81%97%E3%81%9F%E3%81%A8%E3%81%8D%E3%83%9E%E3%83%BC%E3%82%B8%E3%81%97%E3%81%9F%E9%83%A8%E5%88%86%E3%81%AE%E5%BA%8A%E3%82%92%E7%94%9F%E6%88%90%E3%81%99%E3%82%8B%E3%82%88%E3%81%86%E3%81%AB%E3%81%99%E3%82%8B-%EF%BC%8B-%E8%A6%8B%E3%81%88%E3%81%AA%E3%81%84%E5%A3%81)に対するPRです。


# 主な変更、追加箇所  
-マップの端に見えない壁を追加しました。
-マージされたマップの床の大きさがブロックの位置に合わせて変わるようにしました。
-処理上、床が生成されるのが遅れてしまい、タイミングによっては床やブロックに埋まってスタックしてしまうので、スポーン地点付近に見えない床を設置しました。

# 詳細
通常のマップでの壁の大きさは正確ですが、マージされたマップの床の大きさは処理上、-X方向と-Z方向の壁は正確に配置できますがX,Z方向は床の大きさよりも壁の大きさが大きくなってしまう事が多々あったので、それらの方向の壁は遊びを持たせて配置してあります。

また、直接は関係ないですが現在自分の環境だとマージマップの作成がdevelopでも上手くできないです。(今回のタスクは通常のマップを一時的にマージマップ判定で処理を行わせて開発しました。)此方に問題があるかもしれませんが一応報告させて頂きます。

